### PR TITLE
require nokogiri in gem root

### DIFF
--- a/lib/effective_posts.rb
+++ b/lib/effective_posts.rb
@@ -1,5 +1,6 @@
 require 'kaminari'
 require 'migrant'     # Required for rspec to run properly
+require 'nokogiri'
 require "effective_posts/engine"
 
 module EffectivePosts


### PR DESCRIPTION
Effective Posts uses nokogiri to parse and truncate html to create a "Read More..." preview.  The code is here: https://github.com/code-and-effect/effective_posts/blob/master/app/helpers/effective_truncate_html_helper.rb.

Need to require it though...
